### PR TITLE
Add multi-wave tabs and remove screen printing

### DIFF
--- a/kalkulator/ui.py
+++ b/kalkulator/ui.py
@@ -12,100 +12,41 @@ from .printing import (
     PrinterError,
     build_summary_csv,
     print_text_document,
-    print_widget_as_image,
 )
 
 
-class FalaBApp(ttk.Frame):
-    """Główne okno aplikacji kalkulatora."""
+WAVE_TABS = [
+    "FALA B",
+    "FALA E",
+    "FALA C+EB",
+    "FALA EB+B 203",
+    "FALA BC",
+    "F203 FALA BC",
+    "F200 B+ EB",
+    "F200 BC",
+]
 
-    def __init__(self, master: tk.Tk):
-        super().__init__(master, padding=12)
-        self.master.title("Kalkulator Rekruso")
-        self.grid(sticky="nsew")
 
-        self.config = ConfigManager()
-        self.margin_rules: list[dict[str, float]] = self.config.get_margin_rules()
-        self.settings_unlocked = False
+class CalculatorTab(ttk.Frame):
+    """Pojedyncza zakładka kalkulatora odpowiadająca konkretnej fali."""
+
+    def __init__(self, master: ttk.Notebook, app: "FalaBApp", wave_name: str):
+        super().__init__(master)
+        self.app = app
+        self.wave_name = wave_name
         self.last_results: Dict[str, Any] = {}
 
         self._init_variables()
-        self.create_widgets()
-        self.master.bind("<Return>", lambda _event: self.policz())
-
-    # ------------------------------------------------------------------
-    # Inicjalizacja zmiennych powiązanych z interfejsem
-    # ------------------------------------------------------------------
-    def _init_variables(self) -> None:
-        self.var_client_name = tk.StringVar()
-        self.var_client_address = tk.StringVar()
-        self.var_client_nip = tk.StringVar()
-        self.var_client_email = tk.StringVar()
-
-        self.var_dl = tk.StringVar(value="400")
-        self.var_sz = tk.StringVar(value="300")
-        self.var_wys = tk.StringVar(value="200")
-        self.var_gram = tk.StringVar(value="675")
-        self.var_cena_m2 = tk.StringVar(value="1.11")
-
-        self.var_inne = tk.StringVar(value="0")
-
-        self.var_transport_stawka = tk.StringVar(value="2.5")
-        self.var_transport_km = tk.StringVar(value="0")
-        self.var_transport_powrot = tk.BooleanVar(value=True)
-
-        self.var_minimum_aq = tk.StringVar(value=": – szt.")
-        self.var_minimum_con = tk.StringVar(value=": – szt.")
-        self.var_minimum_pg = tk.StringVar(value=": – szt.")
-        self.var_wymiar_h12 = tk.StringVar(value=": – mm")
-        self.var_wymiar_i12 = tk.StringVar(value=": – mm")
-        self.var_wymiar_j12 = tk.StringVar(value=": – mm")
-        self.var_paletyzacja_dl = tk.StringVar(value=": – mm")
-        self.var_paletyzacja_sz = tk.StringVar(value=": – mm")
-        self.var_costs = tk.StringVar(value="–")
-        self.var_transport_info = tk.StringVar(value="–")
-
-        self.var_bigi_row1 = tk.StringVar(value="– mm | – mm | – mm")
-        self.var_bigi_row2 = tk.StringVar(
-            value="Pozycje bigów: – mm | – mm | – mm"
-        )
-        self.var_bigowanie_row1 = tk.StringVar(
-            value="Szerokości segmentów: – mm | – mm | – mm | – mm | – mm"
-        )
-        self.var_bigowanie_row2 = tk.StringVar(
-            value="Pozycje segmentów: – mm | – mm | – mm | – mm | – mm"
-        )
-        self.var_formatka_dims = tk.StringVar(
-            value="Długość: – mm | Szerokość: – mm"
-        )
+        self._build_ui()
 
     # ------------------------------------------------------------------
     # Budowanie interfejsu użytkownika
     # ------------------------------------------------------------------
-    def create_widgets(self) -> None:
-        self.columnconfigure(0, weight=1)
-        self.rowconfigure(0, weight=1)
+    def _build_ui(self) -> None:
+        self.columnconfigure(0, weight=1, uniform="col")
+        self.columnconfigure(1, weight=1, uniform="col")
 
-        self.notebook = ttk.Notebook(self)
-        self.notebook.grid(row=0, column=0, sticky="nsew")
-
-        self.tab_calculator = ttk.Frame(self.notebook)
-        self.tab_settings = ttk.Frame(self.notebook)
-
-        self.notebook.add(self.tab_calculator, text="Kalkulator")
-        self.notebook.add(self.tab_settings, text="Ustawienia")
-
-        self._build_calculator_tab()
-        self._build_settings_tab()
-
-        self.notebook.bind("<<NotebookTabChanged>>", self._on_tab_changed)
-
-    def _build_calculator_tab(self) -> None:
-        tab = self.tab_calculator
-        tab.columnconfigure(0, weight=1, uniform="col")
-        tab.columnconfigure(1, weight=1, uniform="col")
-
-        frame_client = ttk.LabelFrame(tab, text="Dane klienta")
+        frame_client = ttk.LabelFrame(self, text="Dane klienta")
         frame_client.grid(row=0, column=0, columnspan=2, sticky="nsew", pady=(0, 8))
         for col in (1, 3):
             frame_client.columnconfigure(col, weight=1)
@@ -129,7 +70,7 @@ class FalaBApp(ttk.Frame):
             row=1, column=3, sticky="we", pady=(6, 0)
         )
 
-        frame_inputs = ttk.LabelFrame(tab, text="Parametry kartonu i nakłady")
+        frame_inputs = ttk.LabelFrame(self, text="Parametry kartonu i nakłady")
         frame_inputs.grid(row=1, column=0, sticky="nsew", padx=(0, 10), pady=(0, 8))
         for col in (1, 3, 5):
             frame_inputs.columnconfigure(col, weight=1)
@@ -220,7 +161,7 @@ class FalaBApp(ttk.Frame):
                 row=row, column=1, sticky="w", padx=(4, 0)
             )
 
-        frame_right = ttk.Frame(tab)
+        frame_right = ttk.Frame(self)
         frame_right.grid(row=1, column=1, sticky="nsew", pady=(0, 8))
         frame_right.columnconfigure(0, weight=1)
         frame_right.rowconfigure(0, weight=1)
@@ -246,7 +187,7 @@ class FalaBApp(ttk.Frame):
             row=4, column=0, columnspan=2, sticky="w", pady=(4, 0)
         )
 
-        frame_costs = ttk.LabelFrame(tab, text="Koszty dodatkowe i transport")
+        frame_costs = ttk.LabelFrame(self, text="Koszty dodatkowe i transport")
         frame_costs.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=(0, 8))
         for col in (1, 3):
             frame_costs.columnconfigure(col, weight=1)
@@ -275,11 +216,10 @@ class FalaBApp(ttk.Frame):
             variable=self.var_transport_powrot,
         ).grid(row=1, column=2, columnspan=2, sticky="w", pady=(6, 0))
 
-        frame_actions = ttk.Frame(tab)
+        frame_actions = ttk.Frame(self)
         frame_actions.grid(row=3, column=0, columnspan=2, sticky="we", pady=(0, 8))
         frame_actions.columnconfigure(0, weight=1)
         frame_actions.columnconfigure(1, weight=1)
-        frame_actions.columnconfigure(2, weight=1)
 
         ttk.Button(frame_actions, text="Policz", command=self.policz).grid(
             row=0, column=0, sticky="we", padx=(0, 4)
@@ -288,14 +228,9 @@ class FalaBApp(ttk.Frame):
             frame_actions,
             text="Drukuj podsumowanie",
             command=self.print_summary,
-        ).grid(row=0, column=1, sticky="we", padx=4)
-        ttk.Button(
-            frame_actions,
-            text="Drukuj ekran",
-            command=self.print_screen,
-        ).grid(row=0, column=2, sticky="we", padx=(4, 0))
+        ).grid(row=0, column=1, sticky="we", padx=(4, 0))
 
-        frame_results = ttk.LabelFrame(tab, text="Wyniki")
+        frame_results = ttk.LabelFrame(self, text="Wyniki")
         frame_results.grid(row=4, column=0, columnspan=2, sticky="nsew")
         frame_results.columnconfigure(0, weight=1)
 
@@ -306,7 +241,217 @@ class FalaBApp(ttk.Frame):
             row=1, column=0, sticky="w", pady=(0, 8)
         )
 
-        tab.rowconfigure(4, weight=1)
+        self.rowconfigure(4, weight=1)
+
+    # ------------------------------------------------------------------
+    # Logika kalkulatora
+    # ------------------------------------------------------------------
+    def _parse_float(self, var: tk.StringVar, name: str, default: float | None = None) -> float:
+        text = str(var.get()).strip().replace(",", ".")
+        if not text:
+            if default is not None:
+                return default
+            raise ValueError(f"Wymagana wartość w polu: {name}")
+        try:
+            return float(text)
+        except ValueError as exc:
+            raise ValueError(f"Nieprawidłowa wartość w polu: {name}") from exc
+
+    def _parse_float_optional(self, var: tk.StringVar, name: str) -> float:
+        return self._parse_float(var, name, default=0.0)
+
+    def policz(self) -> None:
+        try:
+            dl = self._parse_float(self.var_dl, "DŁ")
+            sz = self._parse_float(self.var_sz, "SZ")
+            wys = self._parse_float(self.var_wys, "WYS")
+            gram = self._parse_float(self.var_gram, "Gramatura")
+            cena_m2 = self._parse_float(self.var_cena_m2, "Cena 1 m²")
+            dodatkowe = self._parse_float_optional(self.var_inne, "Dodatkowe koszty")
+            stawka_km = self._parse_float_optional(
+                self.var_transport_stawka, "Stawka transport"
+            )
+            dystans = self._parse_float_optional(self.var_transport_km, "Dystans km")
+            powrot = bool(self.var_transport_powrot.get())
+        except ValueError as exc:
+            messagebox.showerror("Błąd danych", str(exc))
+            return
+
+        wyniki = oblicz_fala_b(
+            dl=dl,
+            sz=sz,
+            wys=wys,
+            gramatura=gram,
+            cena_m2=cena_m2,
+            dodatkowe_koszty=dodatkowe,
+            stawka_transport_km=stawka_km,
+            dystans_km=dystans,
+            transport_powrot=powrot,
+        )
+
+        bigi = wyniki["bigi"]
+        bigowe = wyniki["bigowe"]
+        sumy_bigowe = wyniki["sumy_bigowe"]
+
+        self.var_bigi_row1.set(
+            f"{bigi['c8']:.2f} mm | {bigi['d8']:.2f} mm | {bigi['e8']:.2f} mm"
+        )
+        self.var_bigi_row2.set(
+            "Pozycje bigów: "
+            + " | ".join(
+                [
+                    f"{sumy_bigowe['c9']:.2f} mm",
+                    f"{sumy_bigowe['d9']:.2f} mm",
+                    f"{sumy_bigowe['e9']:.2f} mm",
+                ]
+            )
+        )
+        self.var_bigowanie_row1.set(
+            "Szerokości segmentów: "
+            + " | ".join(
+                [
+                    f"{bigowe['f8']:.2f} mm",
+                    f"{bigowe['g8']:.2f} mm",
+                    f"{bigowe['h8']:.2f} mm",
+                    f"{bigowe['i8']:.2f} mm",
+                    f"{bigowe['j8']:.2f} mm",
+                ]
+            )
+        )
+        self.var_bigowanie_row2.set(
+            "Pozycje segmentów: "
+            + " | ".join(
+                [
+                    f"{sumy_bigowe['f9']:.2f} mm",
+                    f"{sumy_bigowe['g9']:.2f} mm",
+                    f"{sumy_bigowe['h9']:.2f} mm",
+                    f"{sumy_bigowe['i9']:.2f} mm",
+                    f"{sumy_bigowe['j9']:.2f} mm",
+                ]
+            )
+        )
+        self.var_formatka_dims.set(
+            f"Długość: {wyniki['formatka_mm']:.2f} mm | "
+            f"Szerokość: {wyniki['wymiar_zewnetrzny_mm']:.2f} mm"
+        )
+
+        minimum = wyniki["minimum_produkcji"]
+        self.var_minimum_aq.set(f": {minimum['aq']:.0f} szt.")
+        self.var_minimum_con.set(f": {minimum['con']:.0f} szt.")
+        self.var_minimum_pg.set(f": {minimum['pg']:.0f} szt.")
+
+        weryf = wyniki["weryfikacja_zewnetrzna"]
+        self.var_wymiar_h12.set(f": {weryf['dl']:.2f} mm")
+        self.var_wymiar_i12.set(f": {weryf['sz']:.2f} mm")
+        self.var_wymiar_j12.set(f": {weryf['wys']:.2f} mm")
+
+        paletyzacja = wyniki["paletyzacja"]
+        self.var_paletyzacja_dl.set(f": {paletyzacja['dlugosc']:.2f} mm")
+        self.var_paletyzacja_sz.set(f": {paletyzacja['szerokosc']:.2f} mm")
+
+        koszt_lines = [
+            f"Zużycie m²/szt.: {wyniki['zuzycie_m2_na_szt']:.3f}",
+            f"Waga kg/szt.: {wyniki['waga_kg_na_szt']:.3f}",
+            f"Koszt materiału/szt.: {wyniki['koszt_mat_na_szt']:.4f} zł",
+        ]
+        if wyniki["koszty_dodatkowe"]:
+            koszt_lines.append(
+                f"Dodatkowe koszty (partia): {wyniki['koszty_dodatkowe']:.2f} zł"
+            )
+        self.var_costs.set("\n".join(koszt_lines))
+
+        transport = wyniki["transport"]
+        powrot_txt = "tak" if transport["powrot"] else "nie"
+        self.var_transport_info.set(
+            f"Transport: stawka {transport['stawka_pelna']:.2f} zł/km, "
+            f"dystans {transport['dystans']:.2f} km, powrót: {powrot_txt}. "
+            f"Koszt łączny: {transport['koszt_calkowity']:.2f} zł"
+        )
+
+        self.last_results = {
+            "client": {
+                "nazwa": self.var_client_name.get().strip(),
+                "adres": self.var_client_address.get().strip(),
+                "nip": self.var_client_nip.get().strip(),
+                "email": self.var_client_email.get().strip(),
+            },
+            "inputs": {
+                "fala": self.wave_name,
+                "dl": dl,
+                "sz": sz,
+                "wys": wys,
+                "gramatura": gram,
+                "cena_m2": cena_m2,
+                "dodatkowe_koszty": dodatkowe,
+                "stawka_transport": stawka_km,
+                "dystans": dystans,
+                "powrot": powrot,
+            },
+            "wyniki": wyniki,
+            "margin_rules": self.app.config.get_margin_rules(),
+        }
+
+    def print_summary(self) -> None:
+        try:
+            summary = build_summary_csv(
+                self.last_results,
+                fallback_margin_rules=self.app.config.get_margin_rules(),
+            )
+        except ValueError as exc:
+            messagebox.showinfo("Brak danych", str(exc))
+            return
+        except Exception as exc:  # pragma: no cover - defensywnie
+            messagebox.showerror(
+                "Błąd",
+                f"Nie udało się przygotować danych do wydruku.\n{exc}",
+            )
+            return
+
+        try:
+            print_text_document(summary, suffix=".csv", prefer_notepad=True)
+        except PrinterError as exc:
+            messagebox.showerror("Błąd drukowania", str(exc))
+            return
+        messagebox.showinfo("Drukowanie", "Podsumowanie zostało wysłane do drukarki.")
+
+
+class FalaBApp(ttk.Frame):
+    """Główne okno aplikacji kalkulatora."""
+
+    def __init__(self, master: tk.Tk):
+        super().__init__(master, padding=12)
+        self.master.title("Kalkulator Rekruso")
+        self.grid(sticky="nsew")
+
+        self.config = ConfigManager()
+        self.margin_rules: list[dict[str, float]] = self.config.get_margin_rules()
+        self.settings_unlocked = False
+        self.calculator_tabs: dict[str, CalculatorTab] = {}
+
+        self.create_widgets()
+        self.master.bind("<Return>", self._handle_return)
+
+    # ------------------------------------------------------------------
+    # Budowanie interfejsu użytkownika
+    # ------------------------------------------------------------------
+    def create_widgets(self) -> None:
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        self.notebook = ttk.Notebook(self)
+        self.notebook.grid(row=0, column=0, sticky="nsew")
+
+        for wave_name in WAVE_TABS:
+            tab = CalculatorTab(self.notebook, self, wave_name)
+            self.notebook.add(tab, text=wave_name)
+            self.calculator_tabs[str(tab)] = tab
+
+        self.tab_settings = ttk.Frame(self.notebook)
+        self.notebook.add(self.tab_settings, text="Ustawienia")
+
+        self._build_settings_tab()
+
+        self.notebook.bind("<<NotebookTabChanged>>", self._on_tab_changed)
 
     def _build_settings_tab(self) -> None:
         tab = self.tab_settings
@@ -632,193 +777,16 @@ class FalaBApp(ttk.Frame):
         self.margin_message_label.configure(foreground="red" if error else "")
 
     # ------------------------------------------------------------------
-    # Logika kalkulatora
+    # Integracja z zakładkami kalkulatora
     # ------------------------------------------------------------------
-    def _parse_float(self, var: tk.StringVar, name: str, default: float | None = None) -> float:
-        text = str(var.get()).strip().replace(",", ".")
-        if not text:
-            if default is not None:
-                return default
-            raise ValueError(f"Wymagana wartość w polu: {name}")
-        try:
-            return float(text)
-        except ValueError as exc:
-            raise ValueError(f"Nieprawidłowa wartość w polu: {name}") from exc
+    def _get_current_calculator_tab(self) -> CalculatorTab | None:
+        current = self.notebook.select()
+        return self.calculator_tabs.get(current)
 
-    def _parse_float_optional(self, var: tk.StringVar, name: str) -> float:
-        return self._parse_float(var, name, default=0.0)
-
-    def policz(self) -> None:
-        try:
-            dl = self._parse_float(self.var_dl, "DŁ")
-            sz = self._parse_float(self.var_sz, "SZ")
-            wys = self._parse_float(self.var_wys, "WYS")
-            gram = self._parse_float(self.var_gram, "Gramatura")
-            cena_m2 = self._parse_float(self.var_cena_m2, "Cena 1 m²")
-            dodatkowe = self._parse_float_optional(self.var_inne, "Dodatkowe koszty")
-            stawka_km = self._parse_float_optional(
-                self.var_transport_stawka, "Stawka transport"
-            )
-            dystans = self._parse_float_optional(self.var_transport_km, "Dystans km")
-            powrot = bool(self.var_transport_powrot.get())
-        except ValueError as exc:
-            messagebox.showerror("Błąd danych", str(exc))
-            return
-
-        wyniki = oblicz_fala_b(
-            dl=dl,
-            sz=sz,
-            wys=wys,
-            gramatura=gram,
-            cena_m2=cena_m2,
-            dodatkowe_koszty=dodatkowe,
-            stawka_transport_km=stawka_km,
-            dystans_km=dystans,
-            transport_powrot=powrot,
-        )
-
-        bigi = wyniki["bigi"]
-        bigowe = wyniki["bigowe"]
-        sumy_bigowe = wyniki["sumy_bigowe"]
-
-        self.var_bigi_row1.set(
-            f"{bigi['c8']:.2f} mm | {bigi['d8']:.2f} mm | {bigi['e8']:.2f} mm"
-        )
-        self.var_bigi_row2.set(
-            "Pozycje bigów: "
-            + " | ".join(
-                [
-                    f"{sumy_bigowe['c9']:.2f} mm",
-                    f"{sumy_bigowe['d9']:.2f} mm",
-                    f"{sumy_bigowe['e9']:.2f} mm",
-                ]
-            )
-        )
-        self.var_bigowanie_row1.set(
-            "Szerokości segmentów: "
-            + " | ".join(
-                [
-                    f"{bigowe['f8']:.2f} mm",
-                    f"{bigowe['g8']:.2f} mm",
-                    f"{bigowe['h8']:.2f} mm",
-                    f"{bigowe['i8']:.2f} mm",
-                    f"{bigowe['j8']:.2f} mm",
-                ]
-            )
-        )
-        self.var_bigowanie_row2.set(
-            "Pozycje segmentów: "
-            + " | ".join(
-                [
-                    f"{sumy_bigowe['f9']:.2f} mm",
-                    f"{sumy_bigowe['g9']:.2f} mm",
-                    f"{sumy_bigowe['h9']:.2f} mm",
-                    f"{sumy_bigowe['i9']:.2f} mm",
-                    f"{sumy_bigowe['j9']:.2f} mm",
-                ]
-            )
-        )
-        self.var_formatka_dims.set(
-            f"Długość: {wyniki['formatka_mm']:.2f} mm | "
-            f"Szerokość: {wyniki['wymiar_zewnetrzny_mm']:.2f} mm"
-        )
-
-        minimum = wyniki["minimum_produkcji"]
-        self.var_minimum_aq.set(f": {minimum['aq']:.0f} szt.")
-        self.var_minimum_con.set(f": {minimum['con']:.0f} szt.")
-        self.var_minimum_pg.set(f": {minimum['pg']:.0f} szt.")
-
-        weryf = wyniki["weryfikacja_zewnetrzna"]
-        self.var_wymiar_h12.set(f": {weryf['dl']:.2f} mm")
-        self.var_wymiar_i12.set(f": {weryf['sz']:.2f} mm")
-        self.var_wymiar_j12.set(f": {weryf['wys']:.2f} mm")
-
-        paletyzacja = wyniki["paletyzacja"]
-        self.var_paletyzacja_dl.set(f": {paletyzacja['dlugosc']:.2f} mm")
-        self.var_paletyzacja_sz.set(f": {paletyzacja['szerokosc']:.2f} mm")
-
-        koszt_lines = [
-            f"Zużycie m²/szt.: {wyniki['zuzycie_m2_na_szt']:.3f}",
-            f"Waga kg/szt.: {wyniki['waga_kg_na_szt']:.3f}",
-            f"Koszt materiału/szt.: {wyniki['koszt_mat_na_szt']:.4f} zł",
-        ]
-        if wyniki["koszty_dodatkowe"]:
-            koszt_lines.append(
-                f"Dodatkowe koszty (partia): {wyniki['koszty_dodatkowe']:.2f} zł"
-            )
-        self.var_costs.set("\n".join(koszt_lines))
-
-        transport = wyniki["transport"]
-        powrot_txt = "tak" if transport["powrot"] else "nie"
-        self.var_transport_info.set(
-            f"Transport: stawka {transport['stawka_pelna']:.2f} zł/km, "
-            f"dystans {transport['dystans']:.2f} km, powrót: {powrot_txt}. "
-            f"Koszt łączny: {transport['koszt_calkowity']:.2f} zł"
-        )
-
-        self.last_results = {
-            "client": {
-                "nazwa": self.var_client_name.get().strip(),
-                "adres": self.var_client_address.get().strip(),
-                "nip": self.var_client_nip.get().strip(),
-                "email": self.var_client_email.get().strip(),
-            },
-            "inputs": {
-                "dl": dl,
-                "sz": sz,
-                "wys": wys,
-                "gramatura": gram,
-                "cena_m2": cena_m2,
-                "dodatkowe_koszty": dodatkowe,
-                "stawka_transport": stawka_km,
-                "dystans": dystans,
-                "powrot": powrot,
-            },
-            "wyniki": wyniki,
-            "margin_rules": self.config.get_margin_rules(),
-        }
-
-    # ------------------------------------------------------------------
-    # Drukowanie
-    # ------------------------------------------------------------------
-    def print_summary(self) -> None:
-        try:
-            summary = build_summary_csv(
-                self.last_results,
-                fallback_margin_rules=self.config.get_margin_rules(),
-            )
-        except ValueError as exc:
-            messagebox.showinfo("Brak danych", str(exc))
-            return
-        except Exception as exc:  # pragma: no cover - defensywnie
-            messagebox.showerror(
-                "Błąd",
-                f"Nie udało się przygotować danych do wydruku.\n{exc}",
-            )
-            return
-
-        try:
-            print_text_document(summary, suffix=".csv", prefer_notepad=True)
-        except PrinterError as exc:
-            messagebox.showerror("Błąd drukowania", str(exc))
-            return
-        messagebox.showinfo("Drukowanie", "Podsumowanie zostało wysłane do drukarki.")
-
-    def print_screen(self) -> None:
-        try:
-            print_widget_as_image(self.master)
-        except PrinterError as exc:
-            messagebox.showerror("Błąd drukowania", str(exc))
-        except Exception as exc:  # pragma: no cover - defensywnie
-            messagebox.showerror(
-                "Błąd drukowania",
-                f"Nie udało się przygotować obrazu do druku.\n{exc}",
-            )
-        else:
-            messagebox.showinfo(
-                "Drukowanie",
-                "Obraz aktualnego widoku został wysłany do drukarki.",
-            )
+    def _handle_return(self, _event: tk.Event) -> None:
+        tab = self._get_current_calculator_tab()
+        if tab is not None:
+            tab.policz()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- drop the screen capture printing utilities and related UI button
- refactor the calculator interface into reusable tabs and add the requested FALA tabs
- include the selected wave in printed CSV summaries

## Testing
- python -m compileall kalkulator

------
https://chatgpt.com/codex/tasks/task_e_68cd9ea893dc832d95522e52398ef960